### PR TITLE
🥳 Support output in strftime format

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,11 @@
 ### 💻 CLI
 
 ```sh
+# output default format
 npx moment-guess --date "Fri, January 30th 2020, 10:00 AM"
+
+# output strftime format
+npx moment-guess --date "31st Dec, 2020" --format strftime
 ```
 For details, try `npx moment-guess --help`
 
@@ -36,12 +40,30 @@ npm install moment-guess
 ```javascript
 const guessFormat = require('moment-guess');
 
+// default format
 console.log(guessFormat("31/12/2020")); // DD/MM/YYYY
-console.log(guessFormat("01/01/2020 10:00 AM PST")); // [ 'DD/MM/YYYY hh:mm A z', 'MM/DD/YYYY hh:mm A z' ]
-console.log(guessFormat("Fri, January 30th 2020, 10:00 AM")); // ddd, MMMM Do YYYY, hh:mm A
+
+// default format
+console.log(guessFormat("01/01/2020 10:00 AM PST", "default")); // [ 'DD/MM/YYYY hh:mm A z', 'MM/DD/YYYY hh:mm A z' ]
+
+// strftime format
+console.log(guessFormat("Fri, January 30th 2020, 10:00 AM", "strftime")); // %a, %B %o %Y, %I:%M %p
+
+// Errors!
+try {
+	console.log(guessFormat("Invalid date!"));
+} catch (err) {
+	console.log(err.message); // Couldn't parse date
+}
+
+try {
+	console.log(guessFormat("Mo, 23rd Nov, 2020", "strftime"));
+} catch(err) {
+	console.log(err.message); // Couldn't find strftime modifier for "Mo"
+}
 ```
 
-## 🙌 Supported Formats
+## 🙌 Supported Date Formats
 - *2020-07-24T17:09:03+00:00*([IS0 8601](https://en.wikipedia.org/wiki/ISO_8601))
 
 - *Mon, 06 Mar 2017 21:22:23 +0000*([RFC 2822](https://tools.ietf.org/html/rfc2822#section-3.3))

--- a/cmd/cliui.ts
+++ b/cmd/cliui.ts
@@ -26,6 +26,8 @@ export function showHelp(): void {
 	{bold USAGE}
 
 	{bold $} {cyan npx moment-guess} --date {yellow 2020-10-10}
+	{bold $} {cyan npx moment-guess} --date "{yellow 31st Dec, 2020}" --format {blue default}
+	{bold $} {cyan npx moment-guess} --date "{yellow Mon, 06 Mar 2017 21:00:00 +0000}" --format {blue strftime}
 	{bold $} {cyan npx moment-guess} --version
 	{bold $} {cyan npx moment-guess} --help
 
@@ -36,6 +38,9 @@ export function showHelp(): void {
 	-v, --version                       Displays the current version of moment-guess
 
 	-d, --date                          Displays the provided date's format
+
+	-f, --format                        (optional)Format to display, can be one of "strftime" or "default"
+					    To be used in conjunction with --date
 	`
 	);
 }

--- a/cmd/index.ts
+++ b/cmd/index.ts
@@ -13,17 +13,18 @@ import {
 (function() {
 	let args;
 	let date;
+	let format;
 
 	try {
 		args = arg({
 			'--help': Boolean,
 			'--version': Boolean,
 			'--date': String,
-			'--preference': String,
+			'--format': String,
 			'-h': '--help',
 			'-v': '--version',
 			'-d': '--date',
-			'-p': '--preference',
+			'-f': '--format',
 		});
 
 		if (args['--help']) {
@@ -35,13 +36,16 @@ import {
 		if (args['--date']) {
 			date = args['--date'];
 		}
+		if (args['--format']) {
+			format = args['--format'];
+		}
 
 		if (!date) {
 			error('Missing date!');
 			return showUsage();
 		}
 
-		const res = guessFormat(date);
+		const res = guessFormat(date, format);
 
 		if (res instanceof Array) {
 			info('Multiple formats matched!\n');

--- a/src/Guesser.ts
+++ b/src/Guesser.ts
@@ -1,6 +1,6 @@
 import parsers from './parsers';
 import refiners from './refiners';
-import assigners from './assigners';
+import { strftimeAssigners, defaultAssigners } from './assigners';
 import Token from './parsers/Token';
 
 import {
@@ -34,7 +34,8 @@ export default class Guesser {
 		return refinedParsedResults;
 	}
 
-	static assign(tokens: Array<Token>): void {
+	static assign(tokens: Array<Token>, format?: string): void {
+		let assigners = (!format || format === 'default') ? defaultAssigners : strftimeAssigners;
 		assigners.forEach(assigner => {
 			tokens.forEach(token => {
 				assigner.assign(token);
@@ -45,6 +46,9 @@ export default class Guesser {
 	static getFormatString(tokens: Array<Token>): Format {
 		let formatString: Format = '';
 		tokens.forEach(token => {
+			if (token.format === 'NA') {
+				throw Error(`Couldn't find strftime modifier for "${token.value}"`);
+			}
 			formatString += token.format ? token.format : token.value;
 		});
 		return formatString;

--- a/src/assigners/DayOfMonthFormatTokenAssigner.ts
+++ b/src/assigners/DayOfMonthFormatTokenAssigner.ts
@@ -6,17 +6,25 @@ import {
 class DayOfMonthFormatTokenAssigner implements IAssigner {
 	public readonly name: string;
 	public readonly type: string;
+	public readonly format?: string;
 
 	private _map: Map<RegExp, string>;
 
-	constructor(name: string, type: string) {
+	constructor(name: string, type: string, format?: string) {
 		this.name = name;
 		this.type = type;
+		this.format = format;
 		this._map = new Map();
 
-		this._map.set(/\d{1,2}/, 'D');
-		this._map.set(/\d{2}/, 'DD');
-		this._map.set(/\d{1,2}(?:st|nd|rd|th)/, 'Do');
+		if (!format || format === 'default') {
+			this._map.set(/\d{1,2}/, 'D');
+			this._map.set(/\d{2}/, 'DD');
+			this._map.set(/\d{1,2}(?:st|nd|rd|th)/, 'Do');
+		} else {
+			this._map.set(/\d{1,2}/, '%-e');
+			this._map.set(/\d{2}/, '%d');
+			this._map.set(/\d{1,2}(?:st|nd|rd|th)/, '%o');
+		}
 	}
 
 	private _testTokenType(token: Token): boolean {

--- a/src/assigners/DayOfWeekFormatTokenAssigner.ts
+++ b/src/assigners/DayOfWeekFormatTokenAssigner.ts
@@ -6,19 +6,29 @@ import {
 class DayOfWeekFormatTokenAssigner implements IAssigner {
 	public readonly name: string;
 	public readonly type: string;
+	public readonly format?: string;
 
 	private _map: Map<RegExp, string>;
 
-	constructor(name: string, type: string) {
+	constructor(name: string, type: string, format?: string) {
 		this.name = name;
 		this.type = type;
+		this.format = format;
 		this._map = new Map();
 
-		this._map.set(/[0-6]/, 'd');
-		this._map.set(/[0-6](?:st|nd|rd|th)/, 'do');
-		this._map.set(/(?:Su|Mo|Tu|We|Th|Fr|Sa)/, 'dd');
-		this._map.set(/(?:Sun|Mon|Tue|Wed|Thu|Fri|Sat)/, 'ddd');
-		this._map.set(/(?:Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday)/, 'dddd');
+		if (!format || format === 'default') {
+			this._map.set(/[0-6]/, 'd');
+			this._map.set(/[0-6](?:st|nd|rd|th)/, 'do');
+			this._map.set(/(?:Su|Mo|Tu|We|Th|Fr|Sa)/, 'dd');
+			this._map.set(/(?:Sun|Mon|Tue|Wed|Thu|Fri|Sat)/, 'ddd');
+			this._map.set(/(?:Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday)/, 'dddd');
+		} else {
+			this._map.set(/[0-6]/, '%w');
+			this._map.set(/[0-6](?:st|nd|rd|th)/, 'NA');
+			this._map.set(/(?:Su|Mo|Tu|We|Th|Fr|Sa)/, 'NA');
+			this._map.set(/(?:Sun|Mon|Tue|Wed|Thu|Fri|Sat)/, '%a');
+			this._map.set(/(?:Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday)/, '%A');
+		}
 	}
 
 	private _testTokenType(token: Token): boolean {

--- a/src/assigners/DayOfYearFormatTokenAssigner.ts
+++ b/src/assigners/DayOfYearFormatTokenAssigner.ts
@@ -6,17 +6,25 @@ import {
 class DayOfYearFormatTokenAssigner implements IAssigner {
 	public readonly name: string;
 	public readonly type: string;
+	public readonly format?: string;
 
 	private _map: Map<RegExp, string>;
 
-	constructor(name: string, type: string) {
+	constructor(name: string, type: string, format?: string) {
 		this.name = name;
 		this.type = type;
+		this.format = format;
 		this._map = new Map();
 
-		this._map.set(/\d{1,3}/, 'DDD');
-		this._map.set(/\d{3}/, 'DDDD');
-		this._map.set(/\d{1,3}(?:st|nd|rd|th)/, 'DDDo');
+		if (!format || format === 'default') {
+			this._map.set(/\d{1,3}/, 'DDD');
+			this._map.set(/\d{3}/, 'DDDD');
+			this._map.set(/\d{1,3}(?:st|nd|rd|th)/, 'DDDo');
+		} else {
+			this._map.set(/\d{1,3}/, 'NA');
+			this._map.set(/\d{3}/, '%j');
+			this._map.set(/\d{1,3}(?:st|nd|rd|th)/, 'NA');
+		}
 	}
 
 	private _testTokenType(token: Token): boolean {

--- a/src/assigners/DelimiterFormatTokenAssigner.ts
+++ b/src/assigners/DelimiterFormatTokenAssigner.ts
@@ -6,9 +6,11 @@ import {
 class DelimiterFormatTokenAssigner implements IAssigner {
 	public readonly name: string;
 	public readonly type: string;
+	public readonly format?: string;
 
-	constructor(name: string, type: string) {
+	constructor(name: string, type: string, format?: string) {
 		this.name = name;
+		this.format = format;
 		this.type = type;
 	}
 

--- a/src/assigners/EscapeTextFormatTokenAssigner.ts
+++ b/src/assigners/EscapeTextFormatTokenAssigner.ts
@@ -6,10 +6,12 @@ import {
 class EscapeTextFormatTokenAssigner implements IAssigner {
 	public readonly name: string;
 	public readonly type: string;
+	public readonly format?: string;
 
-	constructor(name: string, type: string) {
+	constructor(name: string, type: string, format?: string) {
 		this.name = name;
 		this.type = type;
+		this.format = format;
 	}
 
 	private _testTokenType(token: Token): boolean {
@@ -18,7 +20,7 @@ class EscapeTextFormatTokenAssigner implements IAssigner {
 
 	public assign(token: Token): void {
 		if (this._testTokenType(token)) {
-			token.format = `[${token.value}]`;
+			token.format = (!this.format || this.format === 'default') ? `[${token.value}]` : token.value;
 		}
 	}
 }

--- a/src/assigners/ISODayOfWeekFormatTokenAssigner.ts
+++ b/src/assigners/ISODayOfWeekFormatTokenAssigner.ts
@@ -6,15 +6,21 @@ import {
 class ISODayOfWeekFormatTokenAssigner implements IAssigner {
 	public readonly name: string;
 	public readonly type: string;
+	public readonly format?: string;
 
 	private _map: Map<RegExp, string>;
 
-	constructor(name: string, type: string) {
+	constructor(name: string, type: string, format?: string) {
 		this.name = name;
 		this.type = type;
+		this.format = format;
 		this._map = new Map();
 
-		this._map.set(/[1-7]/, 'E');
+		if (!format || format === 'default') {
+			this._map.set(/[1-7]/, 'E');
+		} else {
+			this._map.set(/[1-7]/, '%u');
+		}
 	}
 
 	private _testTokenType(token: Token): boolean {

--- a/src/assigners/ISOWeekOfYearFormatTokenAssigner.ts
+++ b/src/assigners/ISOWeekOfYearFormatTokenAssigner.ts
@@ -6,17 +6,25 @@ import {
 class ISOWeekOfYearFormatTokenAssigner implements IAssigner {
 	public readonly name: string;
 	public readonly type: string;
+	public readonly format?: string;
 
 	private _map: Map<RegExp, string>;
 
-	constructor(name: string, type: string) {
+	constructor(name: string, type: string, format?: string) {
 		this.name = name;
 		this.type = type;
+		this.format = format;
 		this._map = new Map();
 
-		this._map.set(/\d{1,2}/, 'W');
-		this._map.set(/\d{2}/, 'WW');
-		this._map.set(/\d{1,2}(?:st|nd|rd|th)/, 'Wo');
+		if (!format || format === 'default') {
+			this._map.set(/\d{1,2}/, 'W');
+			this._map.set(/\d{2}/, 'WW');
+			this._map.set(/\d{1,2}(?:st|nd|rd|th)/, 'Wo');
+		} else {
+			this._map.set(/\d{1,2}/, 'NA');
+			this._map.set(/\d{2}/, '%U');
+			this._map.set(/\d{1,2}(?:st|nd|rd|th)/, 'NA');
+		}
 	}
 
 	private _testTokenType(token: Token): boolean {

--- a/src/assigners/MeridiemFormatTokenAssigner.ts
+++ b/src/assigners/MeridiemFormatTokenAssigner.ts
@@ -6,16 +6,23 @@ import {
 class MeridiemFormatTokenAssigner implements IAssigner {
 	public readonly name: string;
 	public readonly type: string;
+	public readonly format?: string;
 
 	private _map: Map<RegExp, string>;
 
-	constructor(name: string, type: string) {
+	constructor(name: string, type: string, format?: string) {
 		this.name = name;
 		this.type = type;
+		this.format = format;
 		this._map = new Map();
 
-		this._map.set(/am|pm/, 'a');
-		this._map.set(/AM|PM/, 'A');
+		if (!format || format === 'default') {
+			this._map.set(/am|pm/, 'a');
+			this._map.set(/AM|PM/, 'A');
+		} else {
+			this._map.set(/am|pm/, '%P');
+			this._map.set(/AM|PM/, '%p');
+		}
 	}
 
 	private _testTokenType(token: Token): boolean {

--- a/src/assigners/MillisecondFormatTokenAssigner.ts
+++ b/src/assigners/MillisecondFormatTokenAssigner.ts
@@ -6,17 +6,25 @@ import {
 class MillisecondFormatTokenAssigner implements IAssigner {
 	public readonly name: string;
 	public readonly type: string;
+	public readonly format?: string;
 
 	private _map: Map<RegExp, string>;
 
-	constructor(name: string, type: string) {
+	constructor(name: string, type: string, format?: string) {
 		this.name = name;
 		this.type = type;
+		this.format = format;
 		this._map = new Map();
 
-		this._map.set(/\d/, 'S');
-		this._map.set(/\d{2}/, 'SS');
-		this._map.set(/\d{3}/, 'SSS');
+		if (!format || format === 'default') {
+			this._map.set(/\d/, 'S');
+			this._map.set(/\d{2}/, 'SS');
+			this._map.set(/\d{3}/, 'SSS');
+		} else {
+			this._map.set(/\d/, 'NA');
+			this._map.set(/\d{2}/, 'NA');
+			this._map.set(/\d{3}/, '%L');
+		}
 	}
 
 	private _testTokenType(token: Token): boolean {

--- a/src/assigners/MinuteFormatTokenAssigner.ts
+++ b/src/assigners/MinuteFormatTokenAssigner.ts
@@ -6,16 +6,23 @@ import {
 class MinuteFormatTokenAssigner implements IAssigner {
 	public readonly name: string;
 	public readonly type: string;
+	public readonly format?: string;
 
 	private _map: Map<RegExp, string>;
 
-	constructor(name: string, type: string) {
+	constructor(name: string, type: string, format?: string) {
 		this.name = name;
 		this.type = type;
+		this.format = format;
 		this._map = new Map();
 
-		this._map.set(/\d{1,2}/, 'm');
-		this._map.set(/\d{2}/, 'mm');
+		if (!format || format === 'default') {
+			this._map.set(/\d{1,2}/, 'm');
+			this._map.set(/\d{2}/, 'mm');
+		} else {
+			this._map.set(/\d{1,2}/, 'NA');
+			this._map.set(/\d{2}/, '%M');
+		}
 	}
 
 	private _testTokenType(token: Token): boolean {

--- a/src/assigners/MonthFormatTokenAssigner.ts
+++ b/src/assigners/MonthFormatTokenAssigner.ts
@@ -6,19 +6,29 @@ import {
 class MonthFormatTokenAssigner implements IAssigner {
 	public readonly name: string;
 	public readonly type: string;
+	public readonly format?: string;
 
 	private _map: Map<RegExp, string>;
 
-	constructor(name: string, type: string) {
+	constructor(name: string, type: string, format?: string) {
 		this.name = name;
 		this.type = type;
+		this.format = format;
 		this._map = new Map();
 
-		this._map.set(/\d{1,2}/, 'M');
-		this._map.set(/\d{2}/, 'MM');
-		this._map.set(/\d{1,2}(?:st|nd|rd|th)/, 'Mo');
-		this._map.set(/^(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)$/, 'MMM');
-		this._map.set(/^(January|February|March|April|May|June|July|August|September|October|November|December)$/, 'MMMM');
+		if (!format || format === 'default') {
+			this._map.set(/\d{1,2}/, 'M');
+			this._map.set(/\d{2}/, 'MM');
+			this._map.set(/\d{1,2}(?:st|nd|rd|th)/, 'Mo');
+			this._map.set(/^(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)$/, 'MMM');
+			this._map.set(/^(January|February|March|April|May|June|July|August|September|October|November|December)$/, 'MMMM');
+		} else {
+			this._map.set(/\d{1,2}/, 'NA');
+			this._map.set(/\d{2}/, '%m');
+			this._map.set(/\d{1,2}(?:st|nd|rd|th)/, 'NA');
+			this._map.set(/^(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)$/, '%b');
+			this._map.set(/^(January|February|March|April|May|June|July|August|September|October|November|December)$/, '%B');
+		}
 	}
 
 	private _testTokenType(token: Token): boolean {

--- a/src/assigners/SecondFormatTokenAssigner.ts
+++ b/src/assigners/SecondFormatTokenAssigner.ts
@@ -6,16 +6,23 @@ import {
 class SecondFormatTokenAssigner implements IAssigner {
 	public readonly name: string;
 	public readonly type: string;
+	public readonly format?: string;
 
 	private _map: Map<RegExp, string>;
 
-	constructor(name: string, type: string) {
+	constructor(name: string, type: string, format?: string) {
 		this.name = name;
 		this.type = type;
+		this.format = format;
 		this._map = new Map();
 
-		this._map.set(/\d{1,2}/, 's');
-		this._map.set(/\d{2}/, 'ss');
+		if (!format || format === 'default') {
+			this._map.set(/\d{1,2}/, 's');
+			this._map.set(/\d{2}/, 'ss');
+		} else {
+			this._map.set(/\d{1,2}/, 'NA');
+			this._map.set(/\d{2}/, '%S');
+		}
 	}
 
 	private _testTokenType(token: Token): boolean {

--- a/src/assigners/TimezoneFormatTokenAssigner.ts
+++ b/src/assigners/TimezoneFormatTokenAssigner.ts
@@ -6,20 +6,15 @@ import {
 class TimezoneFormatTokenAssigner implements IAssigner {
 	public readonly name: string;
 	public readonly type: string;
+	public readonly format?: string;
 
 	private _map: Map<RegExp, string>;
 
-	constructor(name: string, type: string) {
+	constructor(name: string, type: string, format?: string) {
 		this.name = name;
 		this.type = type;
+		this.format = format;
 		this._map = new Map();
-
-		this._map.set(/[+-]\d{2}(?::\d{2})?/, 'Z');
-		this._map.set(/[+-]\d{4}/, 'ZZ');
-
-		// Treat these as escaped text
-		this._map.set(/Z/, '[Z]');
-		this._map.set(/z/, '[z]');
 
 		const abbreviatedTimezoneRegex = new RegExp(
 			'UT|'
@@ -66,7 +61,26 @@ class TimezoneFormatTokenAssigner implements IAssigner {
 			+ 'ACT|AMST|AMT|ART|BOT|BRST|BRT|CLST|CLT|COT|ECT|FKST|FKT|FNT|GFT|GST|GYT|PET|PYST|PYT|SRT|UYST|UYT|VET|WARST'
 		);
 
-		this._map.set(abbreviatedTimezoneRegex, 'z');
+		if (!format || format === 'default') {
+			this._map.set(/[+-]\d{2}(?::\d{2})?/, 'Z');
+			this._map.set(/[+-]\d{4}/, 'ZZ');
+
+			// Treat these as escaped text
+			this._map.set(/Z/, '[Z]');
+			this._map.set(/z/, '[z]');
+
+
+			this._map.set(abbreviatedTimezoneRegex, 'z');
+		} else {
+			this._map.set(/[+-]\d{2}(?::\d{2})?/, '%:z');
+			this._map.set(/[+-]\d{4}/, '%z');
+
+			// Treat these as escaped text
+			this._map.set(/Z/, 'Z');
+			this._map.set(/z/, 'z');
+
+			this._map.set(abbreviatedTimezoneRegex, '%Z');
+		}
 	}
 
 	private _testTokenType(token: Token): boolean {

--- a/src/assigners/TwelveHourFormatTokenAssigner.ts
+++ b/src/assigners/TwelveHourFormatTokenAssigner.ts
@@ -6,16 +6,23 @@ import {
 class TwelveHourFormatTokenAssigner implements IAssigner {
 	public readonly name: string;
 	public readonly type: string;
+	public readonly format?: string;
 
 	private _map: Map<RegExp, string>;
 
-	constructor(name: string, type: string) {
+	constructor(name: string, type: string, format?: string) {
 		this.name = name;
 		this.type = type;
+		this.format = format;
 		this._map = new Map();
 
-		this._map.set(/^([1-9]|1[0-2])$/, 'h');
-		this._map.set(/^(0\d|1[0-2])$/, 'hh');
+		if (!format || format === 'default') {
+			this._map.set(/^([1-9]|1[0-2])$/, 'h');
+			this._map.set(/^(0\d|1[0-2])$/, 'hh');
+		} else {
+			this._map.set(/^([1-9]|1[0-2])$/, '%l');
+			this._map.set(/^(0\d|1[0-2])$/, '%I');
+		}
 	}
 
 	private _testTokenType(token: Token): boolean {

--- a/src/assigners/TwentyFourHourFormatTokenAssigner.ts
+++ b/src/assigners/TwentyFourHourFormatTokenAssigner.ts
@@ -6,16 +6,23 @@ import {
 class TwentyFourHourFormatTokenAssigner implements IAssigner {
 	public readonly name: string;
 	public readonly type: string;
+	public readonly format?: string;
 
 	private _map: Map<RegExp, string>;
 
-	constructor(name: string, type: string) {
+	constructor(name: string, type: string, format?: string) {
 		this.name = name;
 		this.type = type;
+		this.format = format;
 		this._map = new Map();
 
-		this._map.set(/^(\d|1\d|2[0-3])$/, 'H');
-		this._map.set(/^([0-1]\d|2[0-3])$/, 'HH');
+		if (!format || format === 'default') {
+			this._map.set(/^(\d|1\d|2[0-3])$/, 'H');
+			this._map.set(/^([0-1]\d|2[0-3])$/, 'HH');
+		} else {
+			this._map.set(/^(\d|1\d|2[0-3])$/, '%k');
+			this._map.set(/^([0-1]\d|2[0-3])$/, '%H');
+		}
 	}
 
 	private _testTokenType(token: Token): boolean {

--- a/src/assigners/YearFormatTokenAssigner.ts
+++ b/src/assigners/YearFormatTokenAssigner.ts
@@ -6,17 +6,25 @@ import {
 class YearFormatTokenAssigner implements IAssigner {
 	public readonly name: string;
 	public readonly type: string;
+	public readonly format?: string;
 
 	private _map: Map<RegExp, string>;
 
-	constructor(name: string, type: string) {
+	constructor(name: string, type: string, format?: string) {
 		this.name = name;
 		this.type = type;
+		this.format = format;
 		this._map = new Map();
 
-		this._map.set(/\d{2}/, 'YY');
-		this._map.set(/\d{4}/, 'YYYY');
-		this._map.set(/[+-]\d{6}/, 'YYYYYY');
+		if (!format || format === 'default') {
+			this._map.set(/\d{2}/, 'YY');
+			this._map.set(/\d{4}/, 'YYYY');
+			this._map.set(/[+-]\d{6}/, 'YYYYYY');
+		} else {
+			this._map.set(/\d{2}/, '%y');
+			this._map.set(/\d{4}/, '%Y');
+			this._map.set(/[+-]\d{6}/, 'NA');
+		}
 	}
 
 	private _testTokenType(token: Token): boolean {

--- a/src/assigners/index.ts
+++ b/src/assigners/index.ts
@@ -32,7 +32,24 @@ const twelveHourFormatTokenAssigner = new TwelveHourFormatTokenAssigner('TwelveH
 const twentyFourHourFormatTokenAssigner = new TwentyFourHourFormatTokenAssigner('TwentyFourHourFormatTokenAssigner', 'twentyFourHour');
 const yearFormatTokenAssigner = new YearFormatTokenAssigner('YearFormatTokenAssigner', 'year');
 
-const assigners = [
+const strftimeDayOfMonthFormatTokenAssigner = new DayOfMonthFormatTokenAssigner('DelimiterFormatTokenAssigner', 'dayOfMonth', 'strftime');
+const strftimeDayOfWeekFormatTokenAssigner = new DayOfWeekFormatTokenAssigner('DayOfWeekFormatTokenAssigner', 'dayOfWeek', 'strftime');
+const strftimeDayOfYearFormatTokenAssigner  = new DayOfYearFormatTokenAssigner('DayOfYearFormatTokenAssigner', 'dayOfYear', 'strftime');
+const strftimeDelimiterFormatTokenAssigner = new DelimiterFormatTokenAssigner('DelimiterFormatTokenAssigner', 'delimiter', 'strftime');
+const strftimeEscapeTextFormatTokenAssigner = new EscapeTextFormatTokenAssigner('EscapeTextFormatTokenAssigner', 'escapeText', 'strftime');
+const strftimeISODayOfWeekFormatTokenAssigner = new ISODayOfWeekFormatTokenAssigner('ISODayOfWeekFormatTokenAssigner', 'isoDayOfWeek', 'strftime');
+const strftimeISOWeekOfYearFormatTokenAssigner = new ISOWeekOfYearFormatTokenAssigner('ISOWeekOfYearFormatTokenAssigner', 'isoWeekOfYear', 'strftime');
+const strftimeMeridiemFormatTokenAssigner = new MeridiemFormatTokenAssigner('MeridiemFormatTokenAssigner', 'meridiem', 'strftime');
+const strftimeMillisecondFormatTokenAssigner = new MillisecondFormatTokenAssigner('MillisecondFormatTokenAssigner', 'millisecond', 'strftime');
+const strftimeMinuteFormatTokenAssigner = new MinuteFormatTokenAssigner('MinuteFormatTokenAssigner', 'minute', 'strftime');
+const strftimeMonthFormatTokenAssigner = new MonthFormatTokenAssigner('MonthFormatTokenAssigner', 'month', 'strftime');
+const strftimeSecondFormatTokenAssigner = new SecondFormatTokenAssigner('SecondFormatTokenAssigner', 'second', 'strftime');
+const strftimeTimezoneFormatTokenAssigner = new TimezoneFormatTokenAssigner('TimezoneFormatTokenAssigner', 'timezone', 'strftime');
+const strftimeTwelveHourFormatTokenAssigner = new TwelveHourFormatTokenAssigner('TwelveHourFormatTokenAssigner', 'twelveHour', 'strftime');
+const strftimeTwentyFourHourFormatTokenAssigner = new TwentyFourHourFormatTokenAssigner('TwentyFourHourFormatTokenAssigner', 'twentyFourHour', 'strftime');
+const strftimeYearFormatTokenAssigner = new YearFormatTokenAssigner('YearFormatTokenAssigner', 'year', 'strftime');
+
+export const defaultAssigners = [
 	yearFormatTokenAssigner,
 	monthFormatTokenAssigner,
 	dayOfMonthFormatTokenAssigner,
@@ -51,4 +68,21 @@ const assigners = [
 	meridiemFormatTokenAssigner,
 ];
 
-export default assigners;
+export const strftimeAssigners = [
+	strftimeDayOfMonthFormatTokenAssigner,
+	strftimeDayOfWeekFormatTokenAssigner,
+	strftimeDayOfYearFormatTokenAssigner,
+	strftimeDelimiterFormatTokenAssigner,
+	strftimeEscapeTextFormatTokenAssigner,
+	strftimeISODayOfWeekFormatTokenAssigner,
+	strftimeISOWeekOfYearFormatTokenAssigner,
+	strftimeMeridiemFormatTokenAssigner,
+	strftimeMillisecondFormatTokenAssigner,
+	strftimeMinuteFormatTokenAssigner,
+	strftimeMonthFormatTokenAssigner,
+	strftimeSecondFormatTokenAssigner,
+	strftimeTimezoneFormatTokenAssigner,
+	strftimeTwelveHourFormatTokenAssigner,
+	strftimeTwentyFourHourFormatTokenAssigner,
+	strftimeYearFormatTokenAssigner,
+];

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,13 +4,13 @@ import {
 	Format,
 } from './types';
 
-export default function guessFormat(date: Date): Array<Format> | Format {
+export default function guessFormat(date: Date, format?: string): Array<Format> | Format {
 	const parsedResults = Guesser.parse(date);
 	const refinedParsedResults = Guesser.refine(parsedResults);
 	if (refinedParsedResults.length === 0) {
 	    throw Error("Couldn't parse date");
 	}
-	refinedParsedResults.forEach(r => Guesser.assign(r.tokens));
+	refinedParsedResults.forEach(r => Guesser.assign(r.tokens, format));
 	let matchedFormats: Array<Format> = [];
 	refinedParsedResults.forEach(r => matchedFormats.push(Guesser.getFormatString(r.tokens)));
 	return (

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,5 +23,6 @@ export interface IRefiner {
 export interface IAssigner {
 	readonly name: string;
 	readonly type: string;
+	readonly format?: string;
 	assign(token: Token): void;
 }

--- a/test/dayOfMonthAndMonthNameDateFormat.test.js
+++ b/test/dayOfMonthAndMonthNameDateFormat.test.js
@@ -3,30 +3,37 @@ const guessFormat = require('../dist/bundle.js');
 describe('Day of month followed by month name type dates', () => {
 	test('# D Mon', () => {
 		expect(guessFormat('1 Jan')).toBe('D MMM');
+		expect(guessFormat('1 Jan', 'strftime')).toBe('%-e %b');
 	});
 
 	test('# D Mon, hh:mm am|pm', () => {
 		expect(guessFormat('1 Jan, 10:00 am')).toBe('D MMM, hh:mm a');
+		expect(guessFormat('1 Jan, 10:00 am', 'strftime')).toBe('%-e %b, %I:%M %P');
 	});
 
 	test('# Mon D, HH:mm', () => {
 		expect(guessFormat('1 Jan, 10:00')).toBe('D MMM, HH:mm');
+		expect(guessFormat('1 Jan, 10:00', 'strftime')).toBe('%-e %b, %H:%M');
 	});
 
 	test('# Mon D, HH:mm, > 12 hours', () => {
 		expect(guessFormat('1 Jan, 13:00')).toBe('D MMM, HH:mm');
+		expect(guessFormat('1 Jan, 13:00', 'strftime')).toBe('%-e %b, %H:%M');
 	});
 
 	test('# D Mon, hh:mm:ss AM|PM', () => {
 		expect(guessFormat('1 Jan, 10:00:59 AM')).toBe('D MMM, hh:mm:ss A');
+		expect(guessFormat('1 Jan, 10:00:59 AM', 'strftime')).toBe('%-e %b, %I:%M:%S %p');
 	});
 
 	test('# Mon D, HH:mm:ss', () => {
 		expect(guessFormat('1 Jan, 10:00:59')).toBe('D MMM, HH:mm:ss');
+		expect(guessFormat('1 Jan, 10:00:59', 'strftime')).toBe('%-e %b, %H:%M:%S');
 	});
 
 	test('# DD Mon', () => {
 		expect(guessFormat('01 Jan')).toBe('DD MMM');
+		expect(guessFormat('01 Jan', 'strftime')).toBe('%d %b');
 	});
 
 	test('# parse valid day of month', () => {
@@ -37,69 +44,88 @@ describe('Day of month followed by month name type dates', () => {
 
 	test('# day of month with ordinal', () => {
 		expect(guessFormat('1st Jan')).toBe('Do MMM');
+		expect(guessFormat('1st Jan', 'strftime')).toBe('%o %b');
 	});
 
 	test('# full month name with D', () => {
 		expect(guessFormat('1 January')).toBe('D MMMM');
+		expect(guessFormat('1 January', 'strftime')).toBe('%-e %B');
 	});
 
 	test('# full month name with DD', () => {
 		expect(guessFormat('31 January')).toBe('DD MMMM');
+		expect(guessFormat('31 January', 'strftime')).toBe('%d %B');
 	});
 
 	test('# full month name, day of month with ordinal', () => {
 		expect(guessFormat('31st January')).toBe('Do MMMM');
+		expect(guessFormat('31st January', 'strftime')).toBe('%o %B');
 	});
 
 	test('# full month name, day of month with ordinal, hhAM|PM', () => {
 		expect(guessFormat('31st January, 10AM')).toBe('Do MMMM, hhA');
+		expect(guessFormat('31st January, 10AM', 'strftime')).toBe('%o %B, %I%p');
 	});
 
 	test('# appended delimiter(s)', () => {
 		expect(guessFormat('31st January, ')).toBe('Do MMMM, ');
+		expect(guessFormat('31st January, ', 'strftime')).toBe('%o %B, ');
 	});
 
 	test('# prepend day of week (shortest)', () => {
 		expect(guessFormat('Su, 31st January')).toBe('dd, Do MMMM');
+		expect(() => {
+			guessFormat('Su, 31st January', 'strftime');
+		}).toThrow();
 	});
 
 	test('# prepend day of week (short)', () => {
 		expect(guessFormat('Sun, 31st January')).toBe('ddd, Do MMMM');
+		expect(guessFormat('Sun, 31st January', 'strftime')).toBe('%a, %o %B');
 	});
 
 	test('# prepend day of week (full)', () => {
 		expect(guessFormat('Sunday, 31st January')).toBe('dddd, Do MMMM');
+		expect(guessFormat('Sunday, 31st January', 'strftime')).toBe('%A, %o %B');
 	});
 
 	test('# append year (short)', () => {
 		expect(guessFormat('31st January, 20')).toBe('Do MMMM, YY');
+		expect(guessFormat('31st January, 20', 'strftime')).toBe('%o %B, %y');
 	});
 
 	test('# append year (short), hh:mm am|pm', () => {
 		expect(guessFormat('31st January, 20 10:00 am')).toBe('Do MMMM, YY hh:mm a');
+		expect(guessFormat('31st January, 20 10:00 am', 'strftime')).toBe('%o %B, %y %I:%M %P');
 	});
 
 	test('# append year (short), HH:mm', () => {
 		expect(guessFormat('31st January, 20 10:00')).toBe('Do MMMM, YY HH:mm');
+		expect(guessFormat('31st January, 20 10:00', 'strftime')).toBe('%o %B, %y %H:%M');
 	});
 
 	test('# append year', () => {
 		expect(guessFormat('31st January, 2020')).toBe('Do MMMM, YYYY');
+		expect(guessFormat('31st January, 2020', 'strftime')).toBe('%o %B, %Y');
 	});
 
 	test('# full date', () => {
 		expect(guessFormat('Sunday, 31st January 2020')).toBe('dddd, Do MMMM YYYY');
+		expect(guessFormat('Sunday, 31st January 2020', 'strftime')).toBe('%A, %o %B %Y');
 	});
 
 	test('# full date, hhAM|PM', () => {
 		expect(guessFormat('Sunday, 31st January 2020, 09:00AM')).toBe('dddd, Do MMMM YYYY, hh:mmA');
+		expect(guessFormat('Sunday, 31st January 2020, 09:00AM', 'strftime')).toBe('%A, %o %B %Y, %I:%M%p');
 	});
 
 	test('# full date, HH:mm', () => {
 		expect(guessFormat('Sunday, 31st January 2020, 09:00')).toBe('dddd, Do MMMM YYYY, HH:mm');
+		expect(guessFormat('Sunday, 31st January 2020, 09:00', 'strftime')).toBe('%A, %o %B %Y, %H:%M');
 	});
 
 	test('# full date with abbreviated timezone', () => {
 		expect(guessFormat('Sunday, 31st January 2020, 09:00 IST')).toBe('dddd, Do MMMM YYYY, HH:mm z');
+		expect(guessFormat('Sunday, 31st January 2020, 09:00 IST', 'strftime')).toBe('%A, %o %B %Y, %H:%M %Z');
 	})
 });

--- a/test/iso8601DateTimeFormat.test.js
+++ b/test/iso8601DateTimeFormat.test.js
@@ -3,74 +3,92 @@ const guessFormat = require('../dist/bundle.js');
 describe('ISO 8601 extended date time formats', () => {
 	test('# calendar date part', () => {
 		expect(guessFormat('2020-10-10')).toBe('YYYY-MM-DD');
+		expect(guessFormat('2020-10-10', 'strftime')).toBe('%Y-%m-%d');
 	});
 
 	test('# month date part', () => {
 		expect(guessFormat('2020-10')).toBe('YYYY-MM');
+		expect(guessFormat('2020-10', 'strftime')).toBe('%Y-%m');
 	});
 
 	test('# week date part', () => {
 		expect(guessFormat('2013-W06-5')).toBe('YYYY-[W]WW-E');
+		expect(guessFormat('2013-W06-5', 'strftime')).toBe('%Y-W%U-%u');
 	});
 
 	test('# ordinal date part', () => {
 		expect(guessFormat('2013-039')).toBe('YYYY-DDDD');
+		expect(guessFormat('2013-039', 'strftime')).toBe('%Y-%j');
 	});
 
 	test('# hour time part separated by a T', () => {
 		expect(guessFormat('2013-02-08T09')).toBe('YYYY-MM-DDTHH');
+		expect(guessFormat('2013-02-08T09', 'strftime')).toBe('%Y-%m-%dT%H');
 	});
 
 	test('# hour time part separated by a space', () => {
 		expect(guessFormat('2013-02-08 09')).toBe('YYYY-MM-DD HH');
+		expect(guessFormat('2013-02-08 09', 'strftime')).toBe('%Y-%m-%d %H');
 	});
 
 	test('# hour and minute time part', () => {
 		expect(guessFormat('2013-02-08T09:30')).toBe('YYYY-MM-DDTHH:mm');
+		expect(guessFormat('2013-02-08T09:30', 'strftime')).toBe('%Y-%m-%dT%H:%M');
 	});
 
 	test('# hour, minute, and second time part', () => {
 		expect(guessFormat('2013-02-08T09:30:26')).toBe('YYYY-MM-DDTHH:mm:ss');
+		expect(guessFormat('2013-02-08T09:30:26', 'strftime')).toBe('%Y-%m-%dT%H:%M:%S');
 	});
 
 	test('# hour, minute, second, and millisecond time part', () => {
 		expect(guessFormat('2013-02-08T09:30:26.123')).toBe('YYYY-MM-DDTHH:mm:ss.SSS');
+		expect(guessFormat('2013-02-08T09:30:26.123', 'strftime')).toBe('%Y-%m-%dT%H:%M:%S.%L');
 	});
 
 	test('# hour, minute, second, and millisecond time part, milliseconds separated by a comma', () => {
 		expect(guessFormat('2013-02-08T09:30:26,123')).toBe('YYYY-MM-DDTHH:mm:ss,SSS');
+		expect(guessFormat('2013-02-08T09:30:26,123', 'strftime')).toBe('%Y-%m-%dT%H:%M:%S,%L');
 	});
 
 	test('# calendar date part and hour time part', () => {
 		expect(guessFormat('2013-02-08 09')).toBe('YYYY-MM-DD HH');
+		expect(guessFormat('2013-02-08 09', 'strftime')).toBe('%Y-%m-%d %H');
 	});
 
 	test('# week date part and hour time part', () => {
 		expect(guessFormat('2013-W06-5 09')).toBe('YYYY-[W]WW-E HH');
+		expect(guessFormat('2013-W06-5 09', 'strftime')).toBe('%Y-W%U-%u %H');
 	});
 
 	test('# ordinal date part and hour time part', () => {
 		expect(guessFormat('2013-039 09')).toBe('YYYY-DDDD HH');
+		expect(guessFormat('2013-039 09', 'strftime')).toBe('%Y-%j %H');
 	});
 
 	test('# calendar date and time with hours and timezone +HH:mm', () => {
 		expect(guessFormat('2013-02-08 09+07:00')).toBe('YYYY-MM-DD HHZ');
+		expect(guessFormat('2013-02-08 09+07:00', 'strftime')).toBe('%Y-%m-%d %H%:z');
 	});
 
 	test('# calendar date and time with hours and timezone -HHmm', () => {
 		expect(guessFormat('2013-02-08 09-0100')).toBe('YYYY-MM-DD HHZZ');
+		expect(guessFormat('2013-02-08 09-0100', 'strftime')).toBe('%Y-%m-%d %H%z');
 	});
 
 	test('# calendar date and time with hours and timezone Z', () => {
 		expect(guessFormat('2013-02-08 09Z')).toBe('YYYY-MM-DD HH[Z]');
+		expect(guessFormat('2013-02-08 09Z', 'strftime')).toBe('%Y-%m-%d %HZ');
 	});
 
 	test('# calendar date and full time with timezone +HH:mm', () => {
 		expect(guessFormat('2013-02-08 09:30:26.123+07:00')).toBe('YYYY-MM-DD HH:mm:ss.SSSZ');
+		expect(guessFormat('2013-02-08 09:30:26.123+07:00', 'strftime')).toBe('%Y-%m-%d %H:%M:%S.%L%:z');
 	});
 
 	test('# calendar date and full time with timezone +HH', () => {
 		expect(guessFormat('2013-02-08 09:30:26.123+07')).toBe('YYYY-MM-DD HH:mm:ss.SSSZ');
+		expect(guessFormat('2013-02-08 09:30:26.123+07', 'strftime')).toBe('%Y-%m-%d %H:%M:%S.%L%:z');
 	});
 });
 
@@ -78,65 +96,81 @@ describe('ISO 8601 extended date time formats', () => {
 describe('ISO 8601 basic date time formats', () => {
 	test('# basic (short) full date', () => {
 		expect(guessFormat('20130208')).toBe('YYYYMMDD');
+		expect(guessFormat('20130208', 'strftime')).toBe('%Y%m%d');
 	});
 
 	test('# basic (short) year+month', () => {
 		expect(guessFormat('201303')).toBe('YYYYMM');
+		expect(guessFormat('201303', 'strftime')).toBe('%Y%m');
 	});
 
 	test('# basic (short) year only', () => {
 		expect(guessFormat('2013')).toBe('YYYY');
+		expect(guessFormat('2013', 'strftime')).toBe('%Y');
 	});
 
 	test('# basic (short) week, weekday', () => {
 		expect(guessFormat('2013W065')).toBe('YYYY[W]WWE');
+		expect(guessFormat('2013W065', 'strftime')).toBe('%YW%U%u');
 	});
 
 	test('# basic (short) week only', () => {
 		expect(guessFormat('2013W06')).toBe('YYYY[W]WW');
+		expect(guessFormat('2013W06', 'strftime')).toBe('%YW%U');
 	});
 
 	test('# basic (short) ordinal date (year + day-of-year)', () => {
 		expect(guessFormat('2013050')).toBe('YYYYDDDD');
+		expect(guessFormat('2013050', 'strftime')).toBe('%Y%j');
 	});
 
 	test('# short date and time up to ms, separated by comma', () => {
 		expect(guessFormat('20130208T080910,123')).toBe('YYYYMMDDTHHmmss,SSS');
+		expect(guessFormat('20130208T080910,123', 'strftime')).toBe('%Y%m%dT%H%M%S,%L');
 	});
 
 	test('# short date and time up to ms', () => {
 		expect(guessFormat('20130208T080910.123')).toBe('YYYYMMDDTHHmmss.SSS');
+		expect(guessFormat('20130208T080910.123', 'strftime')).toBe('%Y%m%dT%H%M%S.%L');
 	});
 
 	test('# short date and time up to seconds', () => {
 		expect(guessFormat('20130208T080910')).toBe('YYYYMMDDTHHmmss');
+		expect(guessFormat('20130208T080910', 'strftime')).toBe('%Y%m%dT%H%M%S');
 	});
 
 	test('# short date and time up to minutes', () => {
 		expect(guessFormat('20130208T0809')).toBe('YYYYMMDDTHHmm');
+		expect(guessFormat('20130208T0809', 'strftime')).toBe('%Y%m%dT%H%M');
 	});
 
 	test('# short date and time, hours only', () => {
 		expect(guessFormat('20130208T08')).toBe('YYYYMMDDTHH');
+		expect(guessFormat('20130208T08', 'strftime')).toBe('%Y%m%dT%H');
 	});
 
 	test('# short date and time with hours and timezone +HH:mm', () => {
 		expect(guessFormat('20130208T09+07:00')).toBe('YYYYMMDDTHHZ');
+		expect(guessFormat('20130208T09+07:00', 'strftime')).toBe('%Y%m%dT%H%:z');
 	});
 
 	test('# short date and time with hours and timezone -HHmm', () => {
 		expect(guessFormat('20130208T09-0100')).toBe('YYYYMMDDTHHZZ');
+		expect(guessFormat('20130208T09-0100', 'strftime')).toBe('%Y%m%dT%H%z');
 	});
 
 	test('# short date and time with hours and timezone Z', () => {
 		expect(guessFormat('20130208T09Z')).toBe('YYYYMMDDTHH[Z]');
+		expect(guessFormat('20130208T09Z', 'strftime')).toBe('%Y%m%dT%HZ');
 	});
 
 	test('# short date and full time with timezone +HH:mm', () => {
 		expect(guessFormat('20130208T093026.123+07:00')).toBe('YYYYMMDDTHHmmss.SSSZ');
+		expect(guessFormat('20130208T093026.123+07:00', 'strftime')).toBe('%Y%m%dT%H%M%S.%L%:z');
 	});
 
 	test('# short date and full time with timezone +HH', () => {
 		expect(guessFormat('20130208T093026.123+07')).toBe('YYYYMMDDTHHmmss.SSSZ');
+		expect(guessFormat('20130208T093026.123+07', 'strftime')).toBe('%Y%m%dT%H%M%S.%L%:z');
 	});
 });

--- a/test/monthNameAndDayOfMonthDateFormat.test.js
+++ b/test/monthNameAndDayOfMonthDateFormat.test.js
@@ -3,30 +3,37 @@ const guessFormat = require('../dist/bundle.js');
 describe('Month followed by day of month type dates', () => {
 	test('# Mon D', () => {
 		expect(guessFormat('Jan 1')).toBe('MMM D');
+		expect(guessFormat('Jan 1', 'strftime')).toBe('%b %-e');
 	});
 
 	test('# Mon D, hh:mm am|pm', () => {
 		expect(guessFormat('Jan 1, 10:00 am')).toBe('MMM D, hh:mm a');
+		expect(guessFormat('Jan 1, 10:00 am', 'strftime')).toBe('%b %-e, %I:%M %P');
 	});
 
 	test('# Mon D, HH:mm', () => {
 		expect(guessFormat('Jan 1, 10:00')).toBe('MMM D, HH:mm');
+		expect(guessFormat('Jan 1, 10:00', 'strftime')).toBe('%b %-e, %H:%M');
 	});
 
 	test('# Mon D, HH:mm, > 12 hours', () => {
 		expect(guessFormat('Jan 1, 13:00')).toBe('MMM D, HH:mm');
+		expect(guessFormat('Jan 1, 13:00', 'strftime')).toBe('%b %-e, %H:%M');
 	});
 
 	test('# Mon D, hh:mm:ss AM|PM', () => {
 		expect(guessFormat('Jan 1, 10:00:59 AM')).toBe('MMM D, hh:mm:ss A');
+		expect(guessFormat('Jan 1, 10:00:59 AM', 'strftime')).toBe('%b %-e, %I:%M:%S %p');
 	});
 
 	test('# Mon D, HH:mm:ss', () => {
 		expect(guessFormat('Jan 1, 10:00:59')).toBe('MMM D, HH:mm:ss');
+		expect(guessFormat('Jan 1, 10:00:59', 'strftime')).toBe('%b %-e, %H:%M:%S');
 	});
 
 	test('# Mon DD', () => {
 		expect(guessFormat('Jan 01')).toBe('MMM DD');
+		expect(guessFormat('Jan 01', 'strftime')).toBe('%b %d');
 	});
 
 	test('# parse valid day of month', () => {
@@ -37,69 +44,86 @@ describe('Month followed by day of month type dates', () => {
 
 	test('# day of month with ordinal', () => {
 		expect(guessFormat('Jan 1st')).toBe('MMM Do');
+		expect(guessFormat('Jan 1st', 'strftime')).toBe('%b %o');
 	});
 
 	test('# full month name with D', () => {
 		expect(guessFormat('January 1')).toBe('MMMM D');
+		expect(guessFormat('January 1', 'strftime')).toBe('%B %-e');
 	});
 
 	test('# full month name with DD', () => {
 		expect(guessFormat('January 31')).toBe('MMMM DD');
+		expect(guessFormat('January 31', 'strftime')).toBe('%B %d');
 	});
 
 	test('# full month name, day of month with ordinal', () => {
 		expect(guessFormat('January 31st')).toBe('MMMM Do');
+		expect(guessFormat('January 31st', 'strftime')).toBe('%B %o');
 	});
 
 	test('# full month name, day of month with ordinal, hhAM|PM', () => {
 		expect(guessFormat('January 31st, 10AM')).toBe('MMMM Do, hhA');
+		expect(guessFormat('January 31st, 10AM', 'strftime')).toBe('%B %o, %I%p');
 	});
 
 	test('# appended delimiter(s)', () => {
 		expect(guessFormat('January 31st, ')).toBe('MMMM Do, ');
+		expect(guessFormat('January 31st, ', 'strftime')).toBe('%B %o, ');
 	});
 
 	test('# prepend day of week (shortest)', () => {
 		expect(guessFormat('Su, January 31st')).toBe('dd, MMMM Do');
+		expect(() => guessFormat('Su, January 31st', 'strftime')).toThrow();
 	});
 
 	test('# prepend day of week (short)', () => {
 		expect(guessFormat('Sun, January 31st')).toBe('ddd, MMMM Do');
+		expect(guessFormat('Sun, January 31st', 'strftime')).toBe('%a, %B %o');
 	});
 
 	test('# prepend day of week (full)', () => {
 		expect(guessFormat('Sunday, January 31st')).toBe('dddd, MMMM Do');
+		expect(guessFormat('Sunday, January 31st', 'strftime')).toBe('%A, %B %o');
 	});
 
 	test('# append year (short)', () => {
 		expect(guessFormat('January 31st, 20')).toBe('MMMM Do, YY');
+		expect(guessFormat('January 31st, 20', 'strftime')).toBe('%B %o, %y');
 	});
 
 	test('# append year (short), hh:mm am|pm', () => {
 		expect(guessFormat('January 31st, 20 10:00 am')).toBe('MMMM Do, YY hh:mm a');
+		expect(guessFormat('January 31st, 20 10:00 am', 'strftime')).toBe('%B %o, %y %I:%M %P');
 	});
 
 	test('# append year (short), HH:mm', () => {
 		expect(guessFormat('January 31st, 20 10:00')).toBe('MMMM Do, YY HH:mm');
+		expect(guessFormat('January 31st, 20 10:00', 'strftime')).toBe('%B %o, %y %H:%M');
 	});
 
 	test('# append year', () => {
 		expect(guessFormat('January 31st, 2020')).toBe('MMMM Do, YYYY');
+		expect(guessFormat('January 31st, 2020', 'strftime')).toBe('%B %o, %Y');
 	});
 
 	test('# full date', () => {
 		expect(guessFormat('Sunday, January 31st 2020')).toBe('dddd, MMMM Do YYYY');
+		expect(guessFormat('Sunday, January 31st 2020', 'strftime')).toBe('%A, %B %o %Y');
 	});
 
 	test('# full date, hh:mmAM|PM', () => {
 		expect(guessFormat('Sunday, January 31st 2020, 09:00AM')).toBe('dddd, MMMM Do YYYY, hh:mmA');
+		expect(guessFormat('Sunday, January 31st 2020, 09:00AM', 'strftime')).toBe('%A, %B %o %Y, %I:%M%p');
 	});
 
 	test('# full date, HH:mm', () => {
 		expect(guessFormat('Sunday, January 31st 2020, 09:00')).toBe('dddd, MMMM Do YYYY, HH:mm');
+		expect(guessFormat('Sunday, January 31st 2020, 09:00', 'strftime')).toBe('%A, %B %o %Y, %H:%M');
 	});
 
 	test('# full date with abbreviated timezone', () => {
 		expect(guessFormat('Sunday, January 31st 2020, 09:00 PDT')).toBe('dddd, MMMM Do YYYY, HH:mm z');
+		expect(guessFormat('Sunday, January 31st 2020, 09:00 PDT', 'strftime')).toBe('%A, %B %o %Y, %H:%M %Z');
 	});
 });

--- a/test/rfc2822DateTimeFormat.test.js
+++ b/test/rfc2822DateTimeFormat.test.js
@@ -3,25 +3,31 @@ const guessFormat = require('../dist/bundle.js');
 describe('RFC 2822 date time formats', () => {
 	test('# complete date and time', () => {
 		expect(guessFormat('Mon, 06 Mar 2017 21:22:23 +0000')).toBe('ddd, DD MMM YYYY HH:mm:ss ZZ');
+		expect(guessFormat('Mon, 06 Mar 2017 21:22:23 +0000', 'strftime')).toBe('%a, %d %b %Y %H:%M:%S %z');
 	});
 
 	test('# omit comma after day of week', () => {
 		expect(guessFormat('Mon 06 Mar 2017 21:22:23 z')).toBe('ddd DD MMM YYYY HH:mm:ss [z]');
+		expect(guessFormat('Mon 06 Mar 2017 21:22:23 z', 'strftime')).toBe('%a %d %b %Y %H:%M:%S z');
 	});
 
 	test('# omit day of week', () => {
 		expect(guessFormat('06 Mar 2017 21:22:23 Z')).toBe('DD MMM YYYY HH:mm:ss [Z]');
+		expect(guessFormat('06 Mar 2017 21:22:23 Z', 'strftime')).toBe('%d %b %Y %H:%M:%S Z');
 	});
 
 	test('# single digit day of month', () => {
 		expect(guessFormat('6 Mar 2017 21:22:23 GMT')).toBe('D MMM YYYY HH:mm:ss z');
+		expect(guessFormat('6 Mar 2017 21:22:23 GMT', 'strftime')).toBe('%-e %b %Y %H:%M:%S %Z');
 	});
 
 	test('# two digit year', () => {
 		expect(guessFormat('6 Mar 17 21:22:23 UT')).toBe('D MMM YY HH:mm:ss z');
+		expect(guessFormat('6 Mar 17 21:22:23 UT', 'strftime')).toBe('%-e %b %y %H:%M:%S %Z');
 	});
 
 	test('# omit seconds from time', () => {
 		expect(guessFormat('6 Mar 17 21:22 UT')).toBe('D MMM YY HH:mm z');
+		expect(guessFormat('6 Mar 17 21:22 UT', 'strftime')).toBe('%-e %b %y %H:%M %Z');
 	});
 });

--- a/test/slashDelimitedDateFormat.test.js
+++ b/test/slashDelimitedDateFormat.test.js
@@ -3,58 +3,72 @@ const guessFormat = require('../dist/bundle.js');
 describe('Slash, dot or dash delimited date formats', () => {
 	test('# YYYY/MM/DD', () => {
 		expect(guessFormat('2020/01/01')).toBe('YYYY/MM/DD');
+		expect(guessFormat('2020/01/01', 'strftime')).toBe('%Y/%m/%d');
 	});
 
 	test('# YYYY/MM/DD HH:mm z', () => {
 		expect(guessFormat('2020/01/01 17:00 IST')).toBe('YYYY/MM/DD HH:mm z');
+		expect(guessFormat('2020/01/01 17:00 IST', 'strftime')).toBe('%Y/%m/%d %H:%M %Z');
 	});
 
 	test('# YYYY/MM/DD hh:mm A z', () => {
 		expect(guessFormat('2020/01/01 10:00 AM IST')).toBe('YYYY/MM/DD hh:mm A z');
+		expect(guessFormat('2020/01/01 10:00 AM IST', 'strftime')).toBe('%Y/%m/%d %I:%M %p %Z');
 	});
 
 	test('# YYYY.MM.DD', () => {
 		expect(guessFormat('2020.01.01')).toBe('YYYY.MM.DD');
+		expect(guessFormat('2020.01.01', 'strftime')).toBe('%Y.%m.%d');
 	});
 
 	test('# YYYY-MM-DD', () => {
 		expect(guessFormat('2020-01-01')).toBe('YYYY-MM-DD');
+		expect(guessFormat('2020-01-01', 'strftime')).toBe('%Y-%m-%d');
 	});
 
 	test('# YYYY/MM', () => {
 		expect(guessFormat('2020/01')).toBe('YYYY/MM');
+		expect(guessFormat('2020/01', 'strftime')).toBe('%Y/%m');
 	});
 
 	test('# YYYY.MM', () => {
 		expect(guessFormat('2020.01')).toBe('YYYY.MM');
+		expect(guessFormat('2020.01', 'strftime')).toBe('%Y.%m');
 	});
 
 	test('# YYYY-MM', () => {
 		expect(guessFormat('2020-01')).toBe('YYYY-MM');
+		expect(guessFormat('2020-01', 'strftime')).toBe('%Y-%m');
 	});
 
 	test('# YYYY/M/D', () => {
 		expect(guessFormat('2020/1/1')).toBe('YYYY/M/D');
+		expect(() => guessFormat('2020/1/1', 'strftime')).toThrow();
 	});
 
 	test('# YYYY.M.D', () => {
 		expect(guessFormat('2020.1.1')).toBe('YYYY.M.D');
+		expect(() => guessFormat('2020.1.1', 'strftime')).toThrow();
 	});
 
 	test('# YYYY-M-D', () => {
 		expect(guessFormat('2020-1-1')).toBe('YYYY-M-D');
+		expect(() => guessFormat('2020-1-1', 'strftime')).toThrow();
 	});
 
 	test('# YYYY/M', () => {
 		expect(guessFormat('2020/1')).toBe('YYYY/M');
+		expect(() => guessFormat('2020/1', 'strftime')).toThrow();
 	});
 
 	test('# YYYY.M', () => {
 		expect(guessFormat('2020.1')).toBe('YYYY.M');
+		expect(() => guessFormat('2020.1', 'strftime')).toThrow();
 	});
 
 	test('# YYYY-M', () => {
 		expect(guessFormat('2020-1')).toBe('YYYY-M');
+		expect(() => guessFormat('2020-1', 'strftime')).toThrow();
 	});
 
 	test('# error on month overflow', () => {
@@ -98,52 +112,77 @@ describe('Slash, dot or dash delimited date formats', () => {
 	// YYYY can be in [0000, 9999] | YY can be in [00, 99]
 
 	test('# MM, DD in range [01, 12] slash delimited', () => {
-		const result = guessFormat('01/02/2020');
+		let result = guessFormat('01/02/2020');
 		expect(result).toBeInstanceOf(Array);
 		expect(result).toHaveLength(2);
 		expect(result).toEqual(expect.arrayContaining(['MM/DD/YYYY', 'DD/MM/YYYY']));
+
+		result = guessFormat('01/02/2020', 'strftime');
+		expect(result).toBeInstanceOf(Array);
+		expect(result).toHaveLength(2);
+		expect(result).toEqual(expect.arrayContaining(["%d/%m/%Y", "%m/%d/%Y"]));
+
 	});
 
 	test('# MM, DD in range [01, 12] dot delimited', () => {
-		const result = guessFormat('01.02.2020');
+		let result = guessFormat('01.02.2020');
 		expect(result).toBeInstanceOf(Array);
 		expect(result).toHaveLength(2);
 		expect(result).toEqual(expect.arrayContaining(['MM.DD.YYYY', 'DD.MM.YYYY']));
+
+		result = guessFormat('01.02.2020', 'strftime');
+		expect(result).toBeInstanceOf(Array);
+		expect(result).toHaveLength(2);
+		expect(result).toEqual(expect.arrayContaining(["%d.%m.%Y", "%m.%d.%Y"]));
+
 	});
 
 	test('# MM, DD in range [01, 12] dash delimited', () => {
-		const result = guessFormat('01-02-2020');
+		let result = guessFormat('01-02-2020');
 		expect(result).toBeInstanceOf(Array);
 		expect(result).toHaveLength(2);
 		expect(result).toEqual(expect.arrayContaining(['MM-DD-YYYY', 'DD-MM-YYYY']));
+
+		result = guessFormat('01-02-2020', 'strftime');
+		expect(result).toBeInstanceOf(Array);
+		expect(result).toHaveLength(2);
+		expect(result).toEqual(expect.arrayContaining(["%d-%m-%Y", "%m-%d-%Y"]));
+
 	});
 
 	test('# MM in range [01, 12], DD in range [13, 31] slash delimted', () => {
 		expect(guessFormat('01/31/2020')).toBe('MM/DD/YYYY');
+		expect(guessFormat('01/31/2020', 'strftime')).toBe('%m/%d/%Y');
 	});
 
 	test('# MM in range [01, 12], DD in range [13, 31] dot delimted', () => {
 		expect(guessFormat('01.31.2020')).toBe('MM.DD.YYYY');
+		expect(guessFormat('01.31.2020', 'strftime')).toBe('%m.%d.%Y');
 	});
 
 	test('# MM in range [01, 12], DD in range [13, 31] dash delimted', () => {
 		expect(guessFormat('01-31-2020')).toBe('MM-DD-YYYY');
+		expect(guessFormat('01-31-2020', 'strftime')).toBe('%m-%d-%Y');
 	});
 
 	test('# DD/MM/YYYY', () => {
 		expect(guessFormat('13/01/2020')).toBe('DD/MM/YYYY');
+		expect(guessFormat('13/01/2020', 'strftime')).toBe('%d/%m/%Y');
 	});
 
 	test('# DD/MM/YYYY hh:mm a z', () => {
 		expect(guessFormat('13/01/2020 01:00 pm EST')).toBe('DD/MM/YYYY hh:mm a z');
+		expect(guessFormat('13/01/2020 01:00 pm EST', 'strftime')).toBe('%d/%m/%Y %I:%M %P %Z');
 	});
 
 	test('# DD.MM.YYYY', () => {
 		expect(guessFormat('13.01.2020')).toBe('DD.MM.YYYY');
+		expect(guessFormat('13.01.2020', 'strftime')).toBe('%d.%m.%Y');
 	});
 
 	test('# DD-MM-YYYY', () => {
 		expect(guessFormat('13-01-2020')).toBe('DD-MM-YYYY');
+		expect(guessFormat('13-01-2020', 'strftime')).toBe('%d-%m-%Y');
 	});
 
 	test('# MM, DD out of range', () => {
@@ -153,152 +192,241 @@ describe('Slash, dot or dash delimited date formats', () => {
 	});
 
 	test('# MM, DD, YY in range [01, 12] slash delimited', () => {
-		const result = guessFormat('01/02/03');
+		let result = guessFormat('01/02/03');
 		expect(result).toBeInstanceOf(Array);
 		expect(result).toHaveLength(3);
 		expect(result).toEqual(expect.arrayContaining(['YY/MM/DD', 'MM/DD/YY', 'DD/MM/YY']));
+
+		result = guessFormat('01/02/03', 'strftime');
+		expect(result).toBeInstanceOf(Array);
+		expect(result).toHaveLength(3);
+		expect(result).toEqual(expect.arrayContaining(["%y/%m/%d", "%d/%m/%y", "%m/%d/%y"]));
+
 	});
 
 	test('# MM, DD, YY in range [01, 12] slash delimited with time', () => {
-		const result = guessFormat('01/02/03 10:00 PM');
+		let result = guessFormat('01/02/03 10:00 PM');
 		expect(result).toBeInstanceOf(Array);
 		expect(result).toHaveLength(3);
 		expect(result).toEqual(expect.arrayContaining(['YY/MM/DD hh:mm A', 'MM/DD/YY hh:mm A', 'DD/MM/YY hh:mm A']));
+
+		result = guessFormat('01/02/03 10:00 PM', 'strftime');
+		expect(result).toBeInstanceOf(Array);
+		expect(result).toHaveLength(3);
+		expect(result).toEqual(expect.arrayContaining(["%y/%m/%d %I:%M %p", "%d/%m/%y %I:%M %p", "%m/%d/%y %I:%M %p"]));
+
 	});
 
 	test('# MM, DD, YY in range [01, 12] dot delimited', () => {
-		const result = guessFormat('01.02.03');
+		let result = guessFormat('01.02.03');
 		expect(result).toBeInstanceOf(Array);
 		expect(result).toHaveLength(4);
 		expect(result).toEqual(expect.arrayContaining(['YY.MM.DD', 'MM.DD.YY', 'DD.MM.YY', 'HH.mm.ss']));
+
+		result = guessFormat('01.02.03', 'strftime');
+		expect(result).toBeInstanceOf(Array);
+		expect(result).toHaveLength(4);
+		expect(result).toEqual(expect.arrayContaining(["%y.%m.%d", "%d.%m.%y", "%m.%d.%y", "%H.%M.%S"]));
 	});
 
 	test('# MM, DD, YY in range [01, 12] dot delimited with colon delimited time', () => {
-		const result = guessFormat('01.02.03 10:00 PDT');
+		let result = guessFormat('01.02.03 10:00 PDT');
 		expect(result).toBeInstanceOf(Array);
 		expect(result).toHaveLength(3);
 		expect(result).toEqual(expect.arrayContaining(['YY.MM.DD HH:mm z', 'MM.DD.YY HH:mm z', 'DD.MM.YY HH:mm z']));
+
+		result = guessFormat('01.02.03 10:00 PDT', 'strftime');
+		expect(result).toBeInstanceOf(Array);
+		expect(result).toHaveLength(3);
+		expect(result).toEqual(expect.arrayContaining(["%y.%m.%d %H:%M %Z", "%d.%m.%y %H:%M %Z", "%m.%d.%y %H:%M %Z"]));
+
 	});
 
 	test('# MM, DD, YY in range [01, 12] dot delimited with dot delimited time', () => {
-		const result = guessFormat('01.02.03 10.00 PDT');
+		let result = guessFormat('01.02.03 10.00 PDT');
 		expect(result).toBeInstanceOf(Array);
 		expect(result).toHaveLength(3);
 		expect(result).toEqual(expect.arrayContaining(['YY.MM.DD HH.mm z', 'MM.DD.YY HH.mm z', 'DD.MM.YY HH.mm z']));
+
+		result = guessFormat('01.02.03 10.00 PDT', 'strftime');
+		expect(result).toBeInstanceOf(Array);
+		expect(result).toHaveLength(3);
+		expect(result).toEqual(expect.arrayContaining(["%y.%m.%d %H.%M %Z", "%d.%m.%y %H.%M %Z", "%m.%d.%y %H.%M %Z"]));
 	});
 
 	test('# MM, DD, YY in range [01, 12] dash delimited', () => {
-		const result = guessFormat('01-02-03');
+		let result = guessFormat('01-02-03');
 		expect(result).toBeInstanceOf(Array);
 		expect(result).toHaveLength(3);
 		expect(result).toEqual(expect.arrayContaining(['YY-MM-DD', 'MM-DD-YY', 'DD-MM-YY']));
+
+		result = guessFormat('01-02-03', 'strftime');
+		expect(result).toBeInstanceOf(Array);
+		expect(result).toHaveLength(3);
+		expect(result).toEqual(expect.arrayContaining(["%y-%m-%d", "%d-%m-%y", "%m-%d-%y"]));
 	})
 
 	test('# YY in range [13, 31] placed first, slash delimited', () => {
-		const result = guessFormat('13/02/01');
+		let result = guessFormat('13/02/01');
 		expect(result).toBeInstanceOf(Array);
 		expect(result).toHaveLength(2);
 		expect(result).toEqual(expect.arrayContaining(['YY/MM/DD', 'DD/MM/YY']));
+
+		result = guessFormat('13/02/01', 'strftime');
+		expect(result).toBeInstanceOf(Array);
+		expect(result).toHaveLength(2);
+		expect(result).toEqual(expect.arrayContaining(["%y/%m/%d", "%d/%m/%y"]));
 	});
 
 	test('# YY in range [13, 31] placed first, dot delimited', () => {
-		const result = guessFormat('13.02.01');
+		let result = guessFormat('13.02.01');
 		expect(result).toBeInstanceOf(Array);
 		expect(result).toHaveLength(3);
 		expect(result).toEqual(expect.arrayContaining(['YY.MM.DD', 'DD.MM.YY', 'HH.mm.ss']));
+
+		result = guessFormat('13.02.01', 'strftime');
+		expect(result).toBeInstanceOf(Array);
+		expect(result).toHaveLength(3);
+		expect(result).toEqual(expect.arrayContaining(["%y.%m.%d", "%d.%m.%y", "%H.%M.%S"]));
+
 	});
 
 	test('# DD/MM/YY', () => {
 		expect(guessFormat('31/01/70')).toBe('DD/MM/YY');
+		expect(guessFormat('31/01/70', 'strftime')).toBe('%d/%m/%y');
 	});
 
 	test('# DD.MM.YY', () => {
 		expect(guessFormat('31.01.70')).toBe('DD.MM.YY');
+		expect(guessFormat('31.01.70', 'strftime')).toBe('%d.%m.%y');
 	});
 
 	test('# DD-MM-YY', () => {
 		expect(guessFormat('31-01-70')).toBe('DD-MM-YY');
+		expect(guessFormat('31-01-70', 'strftime')).toBe('%d-%m-%y');
 	});
 
 	test('# MM/DD/YY', () => {
 		expect(guessFormat('12/31/70')).toBe('MM/DD/YY');
+		expect(guessFormat('12/31/70', 'strftime')).toBe('%m/%d/%y');
 	});
 
 	test('# MM.DD.YY', () => {
 		expect(guessFormat('12.31.70')).toBe('MM.DD.YY');
+		expect(guessFormat('12.31.70', 'strftime')).toBe('%m.%d.%y');
 	});
 
 	test('# MM-DD-YY', () => {
 		expect(guessFormat('12-31-70')).toBe('MM-DD-YY');
+		expect(guessFormat('12-31-70', 'strftime')).toBe('%m-%d-%y');
 	});
 
 	test('# YY/MM/DD', () => {
 		expect(guessFormat('70/12/31')).toBe('YY/MM/DD');
+		expect(guessFormat('70/12/31', 'strftime')).toBe('%y/%m/%d');
 	});
 
 	test('# YY.MM.DD', () => {
 		expect(guessFormat('70.12.31')).toBe('YY.MM.DD');
+		expect(guessFormat('70.12.31', 'strftime')).toBe('%y.%m.%d');
 	});
 
 	test('# YY-MM-DD', () => {
 		expect(guessFormat('70-12-31')).toBe('YY-MM-DD');
+		expect(guessFormat('70-12-31', 'strftime')).toBe('%y-%m-%d');
 	});
 
 	test('# MM, DD in range[01, 12] short form, slash delimited', () => {
-		const result = guessFormat('01/01');
+		let result = guessFormat('01/01');
 		expect(result).toBeInstanceOf(Array);
 		expect(result).toHaveLength(3);
 		expect(result).toEqual(expect.arrayContaining(['YY/MM', 'DD/MM', 'MM/DD']));
+
+		result = guessFormat('01/01', 'strftime');
+		expect(result).toBeInstanceOf(Array);
+		expect(result).toHaveLength(3);
+		expect(result).toEqual(expect.arrayContaining(["%y/%m", "%d/%m", "%m/%d"]));
 	});
 
 	test('# MM, DD in range[01, 12] short form, dot delimited', () => {
-		const result = guessFormat('01.01');
+		let result = guessFormat('01.01');
 		expect(result).toBeInstanceOf(Array);
 		expect(result).toHaveLength(4);
 		expect(result).toEqual(expect.arrayContaining(['YY.MM', 'DD.MM', 'MM.DD', 'HH.mm']));
+
+		result = guessFormat('01.01', 'strftime');
+		expect(result).toBeInstanceOf(Array);
+		expect(result).toHaveLength(4);
+		expect(result).toEqual(expect.arrayContaining(["%y.%m", "%d.%m", "%m.%d", "%H.%M"]));
 	});
 
 	test('# MM, DD in range[01, 12] short form, dash delimited', () => {
-		const result = guessFormat('01-01');
+		let result = guessFormat('01-01');
 		expect(result).toBeInstanceOf(Array);
 		expect(result).toHaveLength(3);
 		expect(result).toEqual(expect.arrayContaining(['YY-MM', 'DD-MM', 'MM-DD']));
+
+		result = guessFormat('01-01', 'strftime');
+		expect(result).toBeInstanceOf(Array);
+		expect(result).toHaveLength(3);
+		expect(result).toEqual(expect.arrayContaining(["%y-%m", "%d-%m", "%m-%d"]));
 	});
 
 	test('# MM/DD', () => {
 		expect(guessFormat('12/31')).toBe('MM/DD');
+		expect(guessFormat('12/31', 'strftime')).toBe('%m/%d');
 	});
 
 	test('# MM.DD', () => {
-		const result = guessFormat('12.31');
-
+		let result = guessFormat('12.31');
 		expect(result).toBeInstanceOf(Array);
 		expect(result).toHaveLength(2);
 		expect(result).toEqual(expect.arrayContaining(['MM.DD', 'HH.mm']));
+
+		result = guessFormat('12.31', 'strftime');
+		expect(result).toBeInstanceOf(Array);
+		expect(result).toHaveLength(2);
+		expect(result).toEqual(expect.arrayContaining(["%m.%d", "%H.%M"]));
 	});
 
 	test('# MM-DD', () => {
 		expect(guessFormat('12-31')).toBe('MM-DD');
+		expect(guessFormat('12-31', 'strftime')).toBe('%m-%d');
 	});
 
 	test('# DD/MM | YY/MM', () => {
-		const result = guessFormat('31/12');
+		let result = guessFormat('31/12');
 		expect(result).toBeInstanceOf(Array);
 		expect(result).toHaveLength(2);
 		expect(result).toEqual(expect.arrayContaining(['DD/MM', 'YY/MM']));
+
+		result = guessFormat('31/12', 'strftime');
+		expect(result).toBeInstanceOf(Array);
+		expect(result).toHaveLength(2);
+		expect(result).toEqual(expect.arrayContaining(["%y/%m", "%d/%m"]));
 	});
 
 	test('# DD.MM | YY.MM', () => {
-		const result = guessFormat('31.12');
+		let result = guessFormat('31.12');
 		expect(result).toBeInstanceOf(Array);
 		expect(result).toHaveLength(2);
 		expect(result).toEqual(expect.arrayContaining(['DD.MM', 'YY.MM']));
+
+		result = guessFormat('31.12', 'strftime');
+		expect(result).toBeInstanceOf(Array);
+		expect(result).toHaveLength(2);
+		expect(result).toEqual(expect.arrayContaining(["%y.%m", "%d.%m"]));
 	});
 
 	test('# DD-MM | YY-MM', () => {
-		const result = guessFormat('31-12');
+		let result = guessFormat('31-12');
 		expect(result).toBeInstanceOf(Array);
 		expect(result).toHaveLength(2);
 		expect(result).toEqual(expect.arrayContaining(['DD-MM', 'YY-MM']));
+
+		result = guessFormat('31-12', 'strftime');
+		expect(result).toBeInstanceOf(Array);
+		expect(result).toHaveLength(2);
+		expect(result).toEqual(expect.arrayContaining(["%y-%m", "%d-%m"]));
 	});
 });

--- a/test/timeFormat.test.js
+++ b/test/timeFormat.test.js
@@ -3,50 +3,62 @@ const guessFormat = require('../dist/bundle.js');
 describe('Time formats', () => {
 	test('# hours and mins, colon sep (24 hr format)', () => {
 		expect(guessFormat('21:22')).toBe('HH:mm');
+		expect(guessFormat('21:22', 'strftime')).toBe('%H:%M');
 	});
 
 	test('# hours and minutes with abbreviated timezone (24 hr format)', () => {
 		expect(guessFormat('21:22 EST')).toBe('HH:mm z');
+		expect(guessFormat('21:22 EST', 'strftime')).toBe('%H:%M %Z');
 	});
 
 	test('# hours and mins, dot sep (24 hr format)', () => {
 		expect(guessFormat('21.22')).toBe('HH.mm');
+		expect(guessFormat('21.22', 'strftime')).toBe('%H.%M');
 	});
 
 	test('# hours, mins and secs, colon sep (24 hr format)', () => {
 		expect(guessFormat('21:22:23')).toBe('HH:mm:ss');
+		expect(guessFormat('21:22:23', 'strftime')).toBe('%H:%M:%S');
 	});
 
 	test('# hours, mins and secs, dot sep (24 hr format)', () => {
 		expect(guessFormat('21.22.23')).toBe('HH.mm.ss');
+		expect(guessFormat('21.22.23', 'strftime')).toBe('%H.%M.%S');
 	});
 
 	test('# hours, mins, secs and millis (24 hr format)', () => {
 		expect(guessFormat('21:22:23.123')).toBe('HH:mm:ss.SSS');
+		expect(guessFormat('21:22:23.123', 'strftime')).toBe('%H:%M:%S.%L');
 	});
 
 	test('# complete time (24 hr format)', () => {
 		expect(guessFormat('21:22:23.123 +0000')).toBe('HH:mm:ss.SSS ZZ');
+		expect(guessFormat('21:22:23.123 +0000', 'strftime')).toBe('%H:%M:%S.%L %z');
 	});
 
 	test('# hours and mins, colon sep (12 hr format, AM|PM)', () => {
 		expect(guessFormat('10:00 PM')).toBe('hh:mm A');
+		expect(guessFormat('10:00 PM', 'strftime')).toBe('%I:%M %p');
 	});
 
 	test('# hours and mins, colon sep (12 hr format, am|pm)', () => {
 		expect(guessFormat('10:00 am')).toBe('hh:mm a');
+		expect(guessFormat('10:00 am', 'strftime')).toBe('%I:%M %P');
 	});
 
 	test('# hours and mins, colon sep (12 hr format, am|pm)', () => {
 		expect(guessFormat('10:00 AM GMT')).toBe('hh:mm A z');
+		expect(guessFormat('10:00 AM GMT', 'strftime')).toBe('%I:%M %p %Z');
 	});
 
 	test('# hours, mins, secs colon sep (12 hr format, am|pm)', () => {
 		expect(guessFormat('10:00:59 am')).toBe('hh:mm:ss a');
+		expect(guessFormat('10:00:59 am', 'strftime')).toBe('%I:%M:%S %P');
 	});
 
 	test('# hours, mins, secs dot sep (12 hr format, am|pm)', () => {
 		expect(guessFormat('10.00.59 am')).toBe('hh.mm.ss a');
+		expect(guessFormat('10.00.59 am', 'strftime')).toBe('%I.%M.%S %P');
 	});
 
 	test('# invalid date (12 hr format, am|pm)', () => {


### PR DESCRIPTION
This PR adds support for [strftime format](https://pubs.opengroup.org/onlinepubs/007908799/xsh/strftime.html) as output via `--format` flag as follows,
```sh
# output strftime format
npx moment-guess --date "31st Dec, 2020" --format strftime
```
 List of supported *strftime modifiers* can be found [here](https://github.com/samsonjs/strftime).